### PR TITLE
Make the `clean_urls` function not to clean facebook, youtube and twitter

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -40,13 +40,6 @@ clean_urls <- function(df, url){
   df[[url]] <- gsub("\\/$", "", df[[url]]) # delete remaining trailing slash
   df[[url]] <- gsub("\\&$", "", df[[url]]) # delete remaining trailing &
 
-  # filter_urls <- c("^http://127.0.0.1", "^https://www.youtube.com/watch$", "^https://www.youtube.com/$", "^http://www.youtube.com/$",
-  #                  "^https://youtu.be$", "^https://m.youtube.com$", "^https://m.facebook.com/story",
-  #                  "^https://m.facebook.com/$", "^https://www.facebook.com/$", "^https://chat.whatsapp.com$",
-  #                  "^http://chat.whatsapp.com$", "^http://wa.me$", "^https://wa.me$", "^https://api.whatsapp.com/send$",
-  #                  "^https://api.whatsapp.com/$", "^https://play.google.com/store/apps/details$", "^https://www.twitter.com/$", "^https://www.twitter.com$",
-  #                  "^https://instagram.com/accounts/login", "^https://www.instagram.com/accounts/login", "^https://t.me/joinchat$")
-
   filter_urls <- c("^http://127.0.0.1", "^https://chat.whatsapp.com$",
                    "^http://chat.whatsapp.com$", "^http://wa.me$", "^https://wa.me$", "^https://api.whatsapp.com/send$",
                    "^https://api.whatsapp.com/$", "^https://play.google.com/store/apps/details$",

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,11 +40,16 @@ clean_urls <- function(df, url){
   df[[url]] <- gsub("\\/$", "", df[[url]]) # delete remaining trailing slash
   df[[url]] <- gsub("\\&$", "", df[[url]]) # delete remaining trailing &
 
-  filter_urls <- c("^http://127.0.0.1", "^https://www.youtube.com/watch$", "^https://www.youtube.com/$", "^http://www.youtube.com/$",
-                   "^https://youtu.be$", "^https://m.youtube.com$", "^https://m.facebook.com/story",
-                   "^https://m.facebook.com/$", "^https://www.facebook.com/$", "^https://chat.whatsapp.com$",
+  # filter_urls <- c("^http://127.0.0.1", "^https://www.youtube.com/watch$", "^https://www.youtube.com/$", "^http://www.youtube.com/$",
+  #                  "^https://youtu.be$", "^https://m.youtube.com$", "^https://m.facebook.com/story",
+  #                  "^https://m.facebook.com/$", "^https://www.facebook.com/$", "^https://chat.whatsapp.com$",
+  #                  "^http://chat.whatsapp.com$", "^http://wa.me$", "^https://wa.me$", "^https://api.whatsapp.com/send$",
+  #                  "^https://api.whatsapp.com/$", "^https://play.google.com/store/apps/details$", "^https://www.twitter.com/$", "^https://www.twitter.com$",
+  #                  "^https://instagram.com/accounts/login", "^https://www.instagram.com/accounts/login", "^https://t.me/joinchat$")
+
+  filter_urls <- c("^http://127.0.0.1", "^https://chat.whatsapp.com$",
                    "^http://chat.whatsapp.com$", "^http://wa.me$", "^https://wa.me$", "^https://api.whatsapp.com/send$",
-                   "^https://api.whatsapp.com/$", "^https://play.google.com/store/apps/details$", "^https://www.twitter.com/$", "^https://www.twitter.com$",
+                   "^https://api.whatsapp.com/$", "^https://play.google.com/store/apps/details$",
                    "^https://instagram.com/accounts/login", "^https://www.instagram.com/accounts/login", "^https://t.me/joinchat$")
 
   df <- df[!grepl(paste(filter_urls, collapse = "|"), df[[url]]), ]


### PR DESCRIPTION
Recently, Facebook changed its algorithm so that as long as you post a link, the reach rate will be lower. And, many of the messages delivered are through sharing twitter, youtube and facebook posts. So I modified `clear_urls` so that articles sharing twitter, youtube and facebook posts are also included in the analysis.